### PR TITLE
Добавление флага -Wl,--strip-all

### DIFF
--- a/cmake/DetectFlags.cmake
+++ b/cmake/DetectFlags.cmake
@@ -41,6 +41,11 @@ else()
   try_append_c_flag( "-march=native" CMAKE_C_FLAGS )
   try_append_c_flag( "-std=c99" CMAKE_C_FLAGS )
   try_append_c_flag( "-pipe" CMAKE_C_FLAGS )
+  
+  # Исключение для MacOS
+  if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+     try_append_c_flag( "-Wl,--strip-all" CMAKE_EXE_LINKER_FLAGS )
+  endif()
 endif()
 
 # -------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION
Данный флаг нарушает сборку в ОС MacOS, поэтому было добавлено исключение для данной системы.

P.S. Была произведена проверка успешной сборки на Ubuntu 18.04.